### PR TITLE
apiclient is depreciated, replaced by googleapiclient

### DIFF
--- a/sopel_modules/youtube/youtube.py
+++ b/sopel_modules/youtube/youtube.py
@@ -9,7 +9,7 @@ from sopel import tools
 import datetime
 import sys
 import re
-import apiclient.discovery
+import googleapiclient.discovery
 if sys.version_info.major < 3:
     int = long
 
@@ -46,7 +46,7 @@ def setup(bot):
         bot.memory['url_callbacks'] = tools.SopelMemory()
     bot.memory['url_callbacks'][regex] = get_info
     global API
-    API = apiclient.discovery.build("youtube", "v3",
+    API = googleapiclient.discovery.build("youtube", "v3",
                                     developerKey=bot.config.youtube.api_key)
 
 


### PR DESCRIPTION
Fixed on my client by updating apiclient reference to googleapiclient. For some reason the name was changed along the line and with this module, the backwards compatibility fix they have does not work. Simpler to use the modern package.